### PR TITLE
Overriding catalog rules index builder.

### DIFF
--- a/Model/Indexer/ProductRuleIndexBuilder.php
+++ b/Model/Indexer/ProductRuleIndexBuilder.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Acquia/CommerceManager/Model/Indexer/ProductRuleIndexBuilder.php
+ *
+ * Acquia Commerce Manager Catalog Rule Index Builder.
+ *
+ * All rights reserved. No unauthorized distribution or reproduction.
+ */
+
+namespace Acquia\CommerceManager\Model\Indexer;
+
+use Magento\CatalogRule\Model\Indexer\IndexBuilder;
+use Acquia\CommerceManager\Helper\ProductBatch as BatchHelper;
+use Magento\CatalogRule\Model\ResourceModel\Rule\CollectionFactory as RuleCollectionFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+use Magento\Eav\Model\Config;
+use Magento\Framework\Stdlib\DateTime as StdlibDateTime;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Catalog\Model\ProductFactory;
+
+/**
+ * ProductRuleIndexBuilder
+ *
+ * Acquia Commerce Manager Catalog Rule Index Builder.
+ */
+class ProductRuleIndexBuilder extends IndexBuilder
+{
+
+    /**
+     * Batch helper.
+     * @var ProductBatch $batchHelper
+     */
+    protected $batchHelper;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        RuleCollectionFactory $ruleCollectionFactory,
+        PriceCurrencyInterface $priceCurrency,
+        ResourceConnection $resource,
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger,
+        Config $eavConfig,
+        StdlibDateTime $dateFormat,
+        DateTime $dateTime,
+        ProductFactory $productFactory,
+        BatchHelper $batchHelper,
+        $batchCount = 1000
+    )
+    {
+        parent::__construct(
+            $ruleCollectionFactory, $priceCurrency, $resource, $storeManager, $logger, $eavConfig, $dateFormat, $dateTime, $productFactory, $batchCount
+        );
+        $this->batchHelper = $batchHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function saveRuleProductPrices($arrData)
+    {
+        // Execute parent processing first.
+        $object = parent::saveRuleProductPrices($arrData);
+
+        $productIds = [];
+
+        try {
+            // Prepare products to send to queue.
+            foreach ($arrData as $key => $data) {
+                $productIds[] = $data['product_id'];
+            }
+
+            // Get batch size from config.
+            $batchSize = $this->batchHelper->getProductPushBatchSize();
+
+            foreach (array_chunk($productIds, $batchSize, TRUE) as $chunk) {
+                $batch = [];
+
+                foreach ($chunk as $productId) {
+                    $batch[$productId] = [
+                        'product_id' => $productId,
+                        'store_id' => null,
+                    ];
+                }
+
+                if (!empty($batch)) {
+                    // Push product ids in queue in batch.
+                    $this->batchHelper->addBatchToQueue($batch);
+
+                    $this->logger->info('Added products to queue for pushing in background.', [
+                        'observer' => 'ProductRuleIndexBuilder::saveRuleProductPrices()',
+                        'batch' => $batch,
+                    ]);
+                }
+            }
+        } catch (\Exception $e) {
+            // In case of ACM exception, we just log and process continues.
+            $this->logger->info('Exception occurred with message:' . $e->getMessage(), [
+                'observer' => 'ProductRuleIndexBuilder::saveRuleProductPrices()',
+                'batch' => $productIds,
+            ]);
+        }
+
+        return $object;
+    }
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -32,6 +32,9 @@
     <!-- Class overrides -->
     <preference for ="\Magento\CatalogRule\Model\ResourceModel\Rule\Collection" type="\Acquia\CommerceManager\Model\ResourceModel\Rule\Collection" />
 
+    <!-- Class overrides -->
+    <preference for="Magento\CatalogRule\Model\Indexer\IndexBuilder" type="Acquia\CommerceManager\Model\Indexer\ProductRuleIndexBuilder" />
+
     <!-- Product Relation API Builder / Processors -->
     <preference for="Acquia\CommerceManager\Model\Product\RelationBuilderInterface" type="Acquia\CommerceManager\Model\Product\RelationBuilder" />
     <type name="Acquia\CommerceManager\Model\Product\RelationBuilder">


### PR DESCRIPTION
When promotions are synced from FE, skus are synced to (we get in promotion). But there are chances that indexing is still in progress (not finished) or not started yet and thus user gets wrong SKU price on FE.

So this PR simply sends products/SKUs affected by catalog rule as soon as indexing is finished to the FE