### PR TITLE
Add extended category API collection attribute load method for plugins.

### DIFF
--- a/Model/Category/StoreTree.php
+++ b/Model/Category/StoreTree.php
@@ -111,6 +111,25 @@ class StoreTree extends Tree
     }
 
     /**
+     * Add attributes to the loaded category collection, and allow
+     * plugin methods to add additional extension attributes.
+     *
+     * @param Collection $collection
+     *
+     * @return Collection
+     */
+    public function prepareCollectionAttributes(Collection $collection)
+    {
+        $collection
+            ->addAttributeToSelect('name')
+            ->addAttributeToSelect('is_active')
+            ->addAttributeToSelect('description')
+            ->addAttributeToSelect('include_in_menu');
+
+        return $collection;
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function getChildren($node, $depth, $currentLevel)
@@ -163,13 +182,11 @@ class StoreTree extends Tree
         $storeId = ($storeId) ?: $this->storeManager->getStore()->getId();
 
         $this->categoryCollection
-            ->addAttributeToSelect('name')
-            ->addAttributeToSelect('is_active')
-            ->addAttributeToSelect('description')
-            ->addAttributeToSelect('include_in_menu')
             ->setLoadProductCount(true)
             ->setProductStoreId($storeId)
             ->setStoreId($storeId);
+
+        $this->prepareCollectionAttributes($this->categoryCollection);
     }
 
     /**


### PR DESCRIPTION
Adds a new public method `prepareCollectionAttributes` to the StoreTree / extended category tree API model which adds the needed attributes on the category collection select to populate the tree data. The method is public / called with the collection as an argument for easy use by plugin methods to add additional attributes to the collection select as needed (which would then typically be added to the response extension data by a plugin method on `getTree`). 