### PR TITLE
Fixing exception on sales rule indexer.

### DIFF
--- a/Model/Indexer/SalesRuleBuilder.php
+++ b/Model/Indexer/SalesRuleBuilder.php
@@ -375,12 +375,15 @@ class SalesRuleBuilder
         $prodCond = [];
 
         foreach ($conditions as $cid => $condition) {
-            if ($condition instanceof CombineCondition) {
+          // Get attribute code.
+          $attribute_code = $condition->getData('attribute');
+          if ($condition instanceof CombineCondition) {
                 $prodCond = array_merge(
                     $prodCond,
                     $this->locateProductConditions($condition->getConditions())
                 );
-            } elseif ($condition instanceof ProductCondition) {
+            } elseif ($condition instanceof ProductCondition
+                && strpos($attribute_code, 'quote_item_') !== 0) {
                 $prodCond[] = $condition;
             }
         }


### PR DESCRIPTION
Exception when cart price rule is indexed with the combine condition.

**Steps to reproduce** -

- Create a cart price rule.

- In condition, select the combination condition.

- Then in combination condition, select ant cart condition.

- Save the rule and run indexer.

- There is a fatal/error message - **Invalid attribute name *attribute_name_here***

**Reason for the fatal** - 
In the `SalesRuleBuilder::filterProducts()`, 
`$products->addAttributeToFilter()` assumes the cart attribute as the product attribute and tries to join and thus gives fatal.


