### PR TITLE
Fixing error due to not providing return type.

### DIFF
--- a/Api/Data/TargetRuleProductsInterface.php
+++ b/Api/Data/TargetRuleProductsInterface.php
@@ -111,7 +111,7 @@ interface TargetRuleProductsInterface
     /**
      * Retrieve existing extension attributes object or create a new one.
      *
-     * @return ExtensionInterface|null
+     * @return \Acquia\CommerceManager\Api\Data\TargetRuleProductsExtensionInterface|null
      */
     public function getExtensionAttributes();
 


### PR DESCRIPTION
While fetching/running the related product rules for the SKU, encountered an error 
**ExtensionAttributeFactory::create()**
```
"Method 'getExtensionAttributes' must be overridden in the interfaces...
```

This was caused due to TargetRuleRepository::_getRelatedProductsByType() => TargetRuleProducts::getExtensionAttributes() and inside this method - 

`$extensionAttributes = $this->extensionAttributesFactory->create(TargetRuleProductsInterface::class);`

API endpoint use - 
`{{magento-url}}/rest/V1/products/{{sku-here}}/links_rule/crosssell`