### PR TITLE
Push to only enabled stores on category change from product save.

### DIFF
--- a/Observer/ProductSaveObserver.php
+++ b/Observer/ProductSaveObserver.php
@@ -176,8 +176,9 @@ class ProductSaveObserver extends ConnectorObserver implements ObserverInterface
                 $do_not_push_disabled = $storeProduct->getData(ProductInterface::STATUS) == Status::STATUS_DISABLED;
             }
             else {
-                // Case of an update.
-                if ($product->getStoreId() == 0) {
+                // Case of an update on default store or when update on specific store
+                // with pushing store not matching with current product store.
+                if ($product->getStoreId() == 0 || $storeId != $product->getStoreId()) {
                     // Case of an update on default store view.
                     $do_not_push_disabled = $storeProduct->getData(ProductInterface::STATUS) == Status::STATUS_DISABLED && !($product->getOrigData(ProductInterface::STATUS) == Status::STATUS_ENABLED && $product->getData(ProductInterface::STATUS) == Status::STATUS_DISABLED);
                 }


### PR DESCRIPTION
When the category is changed for the product save on specific store, the product is pushed to all stores as the category is a global scope attribute. But this is also pushing to those stores where the product is disabled.

This will not push the product to disabled stores on category change for the product save